### PR TITLE
Remove deprecation with initializer

### DIFF
--- a/ember-model.js
+++ b/ember-model.js
@@ -2024,7 +2024,7 @@ Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer({
     name: "data-adapter",
 
-    initialize: function(container, application) {
+    initialize: function(application) {
       application.register('data-adapter:main', DebugAdapter);
     }
   });
@@ -2098,7 +2098,7 @@ Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer({
     name: "store",
 
-    initialize: function(_, application) {
+    initialize: function(application) {
       var store = application.Store || Ember.Model.Store;
       application.register('store:application', store);
       application.register('store:main', store);

--- a/packages/ember-model/lib/debug_adapter.js
+++ b/packages/ember-model/lib/debug_adapter.js
@@ -107,7 +107,7 @@ Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer({
     name: "data-adapter",
 
-    initialize: function(container, application) {
+    initialize: function(application) {
       application.register('data-adapter:main', DebugAdapter);
     }
   });

--- a/packages/ember-model/lib/store.js
+++ b/packages/ember-model/lib/store.js
@@ -61,7 +61,7 @@ Ember.onLoad('Ember.Application', function(Application) {
   Application.initializer({
     name: "store",
 
-    initialize: function(_, application) {
+    initialize: function(application) {
       var store = application.Store || Ember.Model.Store;
       application.register('store:application', store);
       application.register('store:main', store);


### PR DESCRIPTION
DEPRECATION: The 'initialize' method
for Application initializer 'store' should
only take one argument
